### PR TITLE
Remove link between type id and value type

### DIFF
--- a/src/knot_protocol.c
+++ b/src/knot_protocol.c
@@ -148,15 +148,6 @@ int knot_type_id_is_logic(uint16_t type_id)
 	return KNOT_ERR_INVALID;
 }
 
-int knot_type_id_is_generic(uint16_t type_id)
-{
-	if (type_id >= KNOT_TYPE_ID_GENERIC_MIN &&
-	    type_id < KNOT_TYPE_ID_GENERIC_MAX)
-		return 0;
-
-	return KNOT_ERR_INVALID;
-}
-
 int knot_schema_is_valid(uint16_t type_id, uint8_t value_type, uint8_t unit)
 {
 	/* int/float/bool/raw/int64/uint/uint64 ? */
@@ -171,8 +162,8 @@ int knot_schema_is_valid(uint16_t type_id, uint8_t value_type, uint8_t unit)
 		} else if (knot_type_id_is_logic(type_id) == 0) {
 			if (unit == KNOT_UNIT_NOT_APPLICABLE)
 				return 0;
-		} else if (knot_type_id_is_generic(type_id) == 0) {
-			if (unit == KNOT_UNIT_NOT_APPLICABLE)
+		} else if (type_id == KNOT_TYPE_ID_GENERIC) {
+			if (unit == KNOT_UNIT_GENERIC)
 				return 0;
 		}
 	}

--- a/src/knot_protocol.c
+++ b/src/knot_protocol.c
@@ -98,42 +98,29 @@
 
 #define TYPE_ID_MASK(type)	(type & 0x000F)
 
-static const struct schema {
-	uint8_t		value_type;
-	uint32_t	unit_mask;
-} basic_types[]  = {
-	{KNOT_VALUE_TYPE_RAW, 0xFFFF			},
-	{KNOT_VALUE_TYPE_INT, UNIT_VOLTAGE_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_CURRENT_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_RESISTANCE_MASK	},
-	{KNOT_VALUE_TYPE_INT, UNIT_POWER_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_TEMP_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_HUM_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_LUM_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_TIME_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_MASS_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_PRESSURE_MASK	},
-	{KNOT_VALUE_TYPE_INT, UNIT_DISTANCE_MASK	},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_ANGLE_MASK		},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_VOL_MASK		},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_AREA_MASK		},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_RAIN_MASK		},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_DENSITY_MASK	},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_LAT_MASK		},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_LONG_MASK		},
-	{KNOT_VALUE_TYPE_INT, UNIT_SPEED_MASK		},
-	{KNOT_VALUE_TYPE_FLOAT, UNIT_VOLFLOW_MASK	},
-	{KNOT_VALUE_TYPE_INT, UNIT_ENERGY_MASK		}
-};
-
-static const uint8_t logic_types[]  = {
-	KNOT_VALUE_TYPE_BOOL,			// KNOT_TYPE_ID_PRESENCE
-	KNOT_VALUE_TYPE_BOOL,			// KNOT_TYPE_ID_SWITCH
-	KNOT_VALUE_TYPE_RAW			// KNOT_TYPE_ID_COMMAND
-};
-
-static const uint8_t generic_types[] = {
-	KNOT_VALUE_TYPE_INT			// KNOT_TYPE_ID_ANALOG
+static const uint32_t basic_types[] = {
+	0xFFFF,
+	UNIT_VOLTAGE_MASK,
+	UNIT_CURRENT_MASK,
+	UNIT_RESISTANCE_MASK,
+	UNIT_POWER_MASK,
+	UNIT_TEMP_MASK,
+	UNIT_HUM_MASK,
+	UNIT_LUM_MASK,
+	UNIT_TIME_MASK,
+	UNIT_MASS_MASK,
+	UNIT_PRESSURE_MASK,
+	UNIT_DISTANCE_MASK,
+	UNIT_ANGLE_MASK,
+	UNIT_VOL_MASK,
+	UNIT_AREA_MASK,
+	UNIT_RAIN_MASK,
+	UNIT_DENSITY_MASK,
+	UNIT_LAT_MASK,
+	UNIT_LONG_MASK,
+	UNIT_SPEED_MASK,
+	UNIT_VOLFLOW_MASK,
+	UNIT_ENERGY_MASK
 };
 
 int knot_value_type_is_valid(uint8_t type)
@@ -172,21 +159,20 @@ int knot_type_id_is_generic(uint16_t type_id)
 
 int knot_schema_is_valid(uint16_t type_id, uint8_t value_type, uint8_t unit)
 {
-	/* int/float/bool/raw ? */
+	/* int/float/bool/raw/int64/uint/uint64 ? */
 	if (knot_value_type_is_valid(value_type) == 0) {
 
 		/* Verify basic type IDs */
 		if (knot_type_id_is_basic(type_id) == 0) {
-			if (basic_types[type_id].value_type == value_type &&
-			    basic_types[type_id].unit_mask & UNIT_MASK(unit))
+			if (basic_types[type_id] & UNIT_MASK(unit))
 				return 0;
 
 		/* Verify logic type IDs */
 		} else if (knot_type_id_is_logic(type_id) == 0) {
-			if (logic_types[TYPE_ID_MASK(type_id)] == value_type)
+			if (unit == KNOT_UNIT_NOT_APPLICABLE)
 				return 0;
 		} else if (knot_type_id_is_generic(type_id) == 0) {
-			if (generic_types[TYPE_ID_MASK(type_id)] == value_type)
+			if (unit == KNOT_UNIT_NOT_APPLICABLE)
 				return 0;
 		}
 	}

--- a/src/knot_protocol.c
+++ b/src/knot_protocol.c
@@ -251,6 +251,30 @@ int knot_config_is_valid(uint8_t event_flags, uint8_t value_type,
 				 */
 				return KNOT_ERR_INVALID;
 			break;
+		case KNOT_VALUE_TYPE_INT64:
+			if (upper_limit->val_i64 < lower_limit->val_i64)
+				/*
+				 * TODO: DEFINE KNOT_CONFIG ERRORS IN PROTOCOL
+				 * KNOT_INVALID_CONFIG in new protocol
+				 */
+				return KNOT_ERR_INVALID;
+			break;
+		case KNOT_VALUE_TYPE_UINT:
+			if (upper_limit->val_u < lower_limit->val_u)
+				/*
+				 * TODO: DEFINE KNOT_CONFIG ERRORS IN PROTOCOL
+				 * KNOT_INVALID_CONFIG in new protocol
+				 */
+				return KNOT_ERR_INVALID;
+			break;
+		case KNOT_VALUE_TYPE_UINT64:
+			if (upper_limit->val_u64 < lower_limit->val_u64)
+				/*
+				 * TODO: DEFINE KNOT_CONFIG ERRORS IN PROTOCOL
+				 * KNOT_INVALID_CONFIG in new protocol
+				 */
+				return KNOT_ERR_INVALID;
+			break;
 		default:
 			/*
 			 * TODO: DEFINE KNOT_CONFIG ERRORS IN PROTOCOL

--- a/src/knot_types.h
+++ b/src/knot_types.h
@@ -56,13 +56,8 @@
 // MAX TypeID for logic units
 #define KNOT_TYPE_ID_LOGIC_MAX				(KNOT_TYPE_ID_COMMAND+1)
 
-// TypeIDs for generic units
-#define KNOT_TYPE_ID_ANALOG				0xFF10
-
-// MIN TypeID for generic units
-#define KNOT_TYPE_ID_GENERIC_MIN			(KNOT_TYPE_ID_ANALOG)
-// MAX TypeID for generic units
-#define KNOT_TYPE_ID_GENERIC_MAX			(KNOT_TYPE_ID_ANALOG+1)
+// TypeID for generic units
+#define KNOT_TYPE_ID_GENERIC				0xFF10
 
 #define KNOT_TYPE_ID_INVALID				0xFFFF
 
@@ -127,6 +122,7 @@
 #define KNOT_UNIT_ENERGY_KWH				0x04
 #define KNOT_UNIT_ENERGY_CAL				0x05
 #define KNOT_UNIT_ENERGY_KCAL				0x06
+#define KNOT_UNIT_GENERIC				0x01
 
 // definition of value type
 #define KNOT_VALUE_TYPE_INT				0x01


### PR DESCRIPTION
Remove the link between the KNOT_TYPE_ID and the KNOT_VALUE_TYPE
allowing the user to choose the most suitable type for its application.